### PR TITLE
Implementing the watch thread stop for kubernetes events

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -1,0 +1,56 @@
+package events
+
+import (
+	"errors"
+)
+
+type Event struct {
+	eventName            string
+	eventWatchStopSwitch chan struct{}
+}
+
+const (
+	Endpoints  string = "endpoints"
+	Services   string = "services"
+	Pods       string = "pods"
+	Secrets    string = "secrets"
+	Ingresses  string = "ingresses"
+	Namespaces string = "namespaces"
+)
+
+var (
+	allowedEventNames = [...]string{Ingresses, Endpoints, Services, Pods, Secrets, Namespaces}
+)
+
+func (ev *Event) GetEventName() string {
+	return ev.eventName
+}
+
+func (ev *Event) GetEventStopChannel() chan struct{} {
+	return ev.eventWatchStopSwitch
+}
+func New(eventName string) (*Event, error) {
+	ev := Event{eventName: eventName, eventWatchStopSwitch: make(chan struct{})}
+	err := ev.validate()
+	if err != nil {
+		return nil, err
+	}
+	return &ev, nil
+}
+func (ev *Event) validate() error {
+	for _, v := range allowedEventNames {
+		if ev.eventName == v {
+			return nil
+		}
+	}
+	return errors.New("Invalid EventName: " + ev.eventName)
+
+}
+
+func (ev *Event) stopEventWatch() {
+	close(ev.eventWatchStopSwitch)
+}
+
+func (ev *Event) DeleteAll() {
+	ev.stopEventWatch()
+}

--- a/pkg/interface/interface_test.go
+++ b/pkg/interface/interface_test.go
@@ -8,6 +8,7 @@ import(
 	"fmt"
 	"os"
         "path/filepath"
+        "multicluster-ingress-controller/pkg/swaggerInterface"
 )
 func TestInitRestInterface(t *testing.T) {
 	Convey("Initializing Citrix Control Plane", t, func(){
@@ -16,7 +17,7 @@ func TestInitRestInterface(t *testing.T) {
 }
 func TestRestInterface(t *testing.T) {
 	StartRestServer()
-	data := createClientServer{}
+	data := swaggerInterface.CreateClientServer{}
 	data.ClusterName = "Cluster-1" 
 	data.ConfigFileName = "/home/.kube/config"
 	data.ServerURL = append(data.ServerURL, "22.22.22.22")

--- a/pkg/kubeController/kubeController.go
+++ b/pkg/kubeController/kubeController.go
@@ -1,0 +1,339 @@
+package kubeController
+
+import (
+	"errors"
+
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/google/uuid"
+	"k8s.io/api/core/v1"
+	v1beta1 "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+	"multicluster-ingress-controller/pkg/events"
+	"multicluster-ingress-controller/pkg/kubeControls"
+	"multicluster-ingress-controller/pkg/kubernetesAPIServer"
+	"multicluster-ingress-controller/pkg/namespaces"
+	"multicluster-ingress-controller/pkg/swaggerInterface"
+	"net/http"
+)
+
+func NewkubeController() *KubeController {
+	return &KubeController{}
+}
+
+type KubeController struct {
+	Api        *kubernetesAPIServer.KubernetesAPIServer
+	ServerList []string
+	kubeState  kubeControls.KubeControl
+}
+
+func (kC *KubeController) DeleteAll() {
+	kC.kubeState.DeleteAll()
+	kC.ServerList = nil
+	kC.Api = nil
+}
+
+func (kC *KubeController) PopulateKubeController(api *kubernetesAPIServer.KubernetesAPIServer, swgClientServer *swaggerInterface.CreateClientServer) error {
+	kC.Api = api
+	kC.ServerList = swgClientServer.ServerURL
+	kCtls := kubeControls.New()
+	err := kCtls.PopulateKubeControls(*swgClientServer)
+	if err != nil {
+		return err
+	}
+	kC.kubeState = *kCtls
+	return nil
+}
+
+func (kC *KubeController) RunWatchEvents() error {
+	kS := kC.kubeState
+	var err error
+	for ns := 0; ns < kS.Namespaceslength(); ns++ {
+		var namespacePtr *namespaces.Namespace
+		namespacePtr, err = kS.GetNamespace(ns)
+		if err != nil {
+			break
+		}
+		namespace := *namespacePtr
+		namespaceName := namespace.GetNamespaceName()
+
+		for ev := 0; ev < namespace.EventsLength(); ev++ {
+			var eventPtr *events.Event
+			eventPtr, err = namespace.GetEvent(ev)
+			if err != nil {
+				break
+			}
+			event := *eventPtr
+			eventName := event.GetEventName()
+			eventStopChannel := event.GetEventStopChannel()
+			err = kC.watchEvent(namespaceName, eventName, eventStopChannel)
+			if err != nil {
+				break
+			}
+		}
+	}
+	if err != nil {
+		kC.DeleteAll()
+		return err
+	}
+	return nil
+}
+
+func (kC *KubeController) watchEvent(namespace string, eventName string, eventStopChannel chan struct{}) error {
+	switch eventName {
+	case events.Endpoints:
+		kC.EndpointWatchPerNamespace(namespace, eventStopChannel)
+	case events.Pods:
+		kC.PodWatchPerNamespace(namespace, eventStopChannel)
+	case events.Services:
+		kC.ServiceWatchPerNamespace(namespace, eventStopChannel)
+	case events.Ingresses:
+		kC.IngressWatchPerNamespace(namespace, eventStopChannel)
+	case events.Secrets:
+		kC.SecretWatchPerNamespace(namespace, eventStopChannel)
+	case events.Namespaces:
+		// No watch event for Namespaces Entity
+	default:
+		return errors.New("INVALID event Name: " + eventName)
+
+	}
+	return nil
+}
+
+func (kC *KubeController) IngressWatchPerNamespace(namespace string, stop chan struct{}) {
+	api := kC.Api
+	klog.Info("[INFO] Watch Ingress for namespace: ", namespaces.GetNamespaceString(namespace))
+
+	ingressListWatcher := cache.NewListWatchFromClient(api.Client.ExtensionsV1beta1().RESTClient(), "ingresses", namespace, fields.Everything())
+	_, controller := cache.NewInformer(ingressListWatcher, &v1beta1.Ingress{}, 0, cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			kC.ingressEventParseAndSendData(obj, "ADDED")
+		},
+		UpdateFunc: func(obj interface{}, newobj interface{}) {
+			kC.ingressEventParseAndSendData(newobj, "MODIFIED")
+		},
+		DeleteFunc: func(obj interface{}) {
+			kC.ingressEventParseAndSendData(obj, "DELETED")
+		},
+	},
+	)
+	go controller.Run(stop)
+
+	return
+}
+
+func (kC *KubeController) SecretWatchPerNamespace(namespace string, stop chan struct{}) {
+	api := kC.Api
+	klog.Info("[INFO] Watch Secret events for namespace: ", namespaces.GetNamespaceString(namespace))
+
+	secretListWatcher := cache.NewListWatchFromClient(api.Client.Core().RESTClient(), "secrets", namespace, fields.Everything())
+	_, controller := cache.NewInformer(secretListWatcher, &v1.Secret{}, 0, cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			kC.secretEventParseAndSendData(obj, "ADDED")
+		},
+		UpdateFunc: func(obj interface{}, newobj interface{}) {
+			kC.secretEventParseAndSendData(newobj, "MODIFIED")
+		},
+		DeleteFunc: func(obj interface{}) {
+			kC.secretEventParseAndSendData(obj, "DELETED")
+		},
+	},
+	)
+	go controller.Run(stop)
+	return
+}
+
+func (kC *KubeController) EndpointWatchPerNamespace(namespace string, stop chan struct{}) {
+	api := kC.Api
+	klog.Info("[INFO] Watch Endpoint for namespace: ", namespaces.GetNamespaceString(namespace))
+
+	endpointListWatcher := cache.NewListWatchFromClient(api.Client.Core().RESTClient(), "endpoints", namespace, fields.Everything())
+	_, controller := cache.NewInformer(endpointListWatcher, &v1.Endpoints{}, 0, cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			kC.endpointEventParseAndSendData(obj, "ADDED")
+		},
+		UpdateFunc: func(obj interface{}, newobj interface{}) {
+			kC.endpointEventParseAndSendData(newobj, "MODIFIED")
+		},
+		DeleteFunc: func(obj interface{}) {
+			kC.endpointEventParseAndSendData(obj, "DELETED")
+		},
+	},
+	)
+
+	go controller.Run(stop)
+	return
+}
+
+func (kC *KubeController) ServiceWatchPerNamespace(namespace string, stop chan struct{}) {
+	api := kC.Api
+	klog.Info("[INFO] Watch Service events for namespace: ", namespaces.GetNamespaceString(namespace))
+	serviceListWatcher := cache.NewListWatchFromClient(api.Client.Core().RESTClient(), string(v1.ResourceServices), namespace, fields.Everything())
+	_, controller := cache.NewInformer(serviceListWatcher, &v1.Service{}, 0, cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			kC.serviceEventParseAndSendData(obj, "ADDED")
+		},
+		UpdateFunc: func(obj interface{}, newobj interface{}) {
+			kC.serviceEventParseAndSendData(newobj, "MODIFIED")
+		},
+		DeleteFunc: func(obj interface{}) {
+			kC.serviceEventParseAndSendData(obj, "DELETED")
+		},
+	},
+	)
+
+	go controller.Run(stop)
+	return
+}
+
+func (kC *KubeController) PodWatchPerNamespace(namespace string, stop chan struct{}) {
+	api := kC.Api
+
+	klog.Info("[INFO] Watch Pods for namespace: ", namespaces.GetNamespaceString(namespace))
+	PodListWatcher := cache.NewListWatchFromClient(api.Client.Core().RESTClient(), string(v1.ResourcePods), namespace, fields.Everything())
+	_, controller := cache.NewInformer(PodListWatcher, &v1.Pod{}, 0, cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			kC.podEventParseAndSendData(obj, "ADDED")
+		},
+		UpdateFunc: func(obj interface{}, newobj interface{}) {
+			kC.podEventParseAndSendData(newobj, "MODIFIED")
+		},
+		DeleteFunc: func(obj interface{}) {
+			kC.podEventParseAndSendData(obj, "DELETED")
+		},
+	},
+	)
+	go controller.Run(stop)
+	return
+}
+
+func (kC *KubeController) endpointEventParseAndSendData(obj interface{}, eventType string) {
+
+	objByte, err := json.Marshal(obj)
+	if err != nil {
+		klog.Errorf("[ERROR] Failed to Marshal original object: %v", err)
+	}
+	var objJson v1.Endpoints
+	if err = json.Unmarshal(objByte, &objJson); err != nil {
+		klog.Errorf("[ERROR] Failed to unmarshal original object: %v", err)
+	}
+	message, err := json.MarshalIndent(objJson, "", "  ")
+	if objJson.ObjectMeta.Namespace == "kube-system" {
+		return
+	}
+	kC.parseAndSendData(string(message), objJson.ObjectMeta, objJson.TypeMeta, "Endpoints", eventType)
+}
+func (kC *KubeController) secretEventParseAndSendData(obj interface{}, eventType string) {
+
+	objByte, err := json.Marshal(obj)
+	if err != nil {
+		klog.Errorf("[ERROR] Failed to Marshal original object: %v", err)
+	}
+	var objJson v1.Secret
+	if err = json.Unmarshal(objByte, &objJson); err != nil {
+		klog.Errorf("[ERROR] Failed to unmarshal original object: %v", err)
+	}
+	if objJson.ObjectMeta.Namespace == "kube-system" {
+		return
+	}
+	message, err := json.MarshalIndent(objJson, "", "  ")
+	kC.parseAndSendData(string(message), objJson.ObjectMeta, obj.(*v1.Secret).TypeMeta, "Secret", eventType)
+
+}
+
+func (kC *KubeController) ingressEventParseAndSendData(obj interface{}, eventType string) {
+
+	objByte, err := json.Marshal(obj)
+	if err != nil {
+		klog.Errorf("[ERROR] Failed to Marshal original object: %v", err)
+	}
+	var objJson v1beta1.Ingress
+	if err = json.Unmarshal(objByte, &objJson); err != nil {
+		klog.Errorf("[ERROR] Failed to unmarshal original object: %v", err)
+	}
+	if objJson.ObjectMeta.Namespace == "kube-system" {
+		return
+	}
+	message, err := json.MarshalIndent(objJson, "", "  ")
+	kC.parseAndSendData(string(message), objJson.ObjectMeta, obj.(*v1beta1.Ingress).TypeMeta, "Ingress", eventType)
+
+}
+
+func (kC *KubeController) podEventParseAndSendData(obj interface{}, eventType string) {
+	objByte, err := json.Marshal(obj)
+	if err != nil {
+		klog.Errorf("[ERROR] Failed to Marshal original object: %v", err)
+	}
+	var objJson v1.Pod
+	if err = json.Unmarshal(objByte, &objJson); err != nil {
+		klog.Errorf("[ERROR] Failed to unmarshal original object: %v", err)
+	}
+	if objJson.ObjectMeta.Namespace == "kube-system" {
+		return
+	}
+	message, err := json.MarshalIndent(objJson, "", "  ")
+	kC.parseAndSendData(string(message), objJson.ObjectMeta, objJson.TypeMeta, "Pod", eventType)
+}
+
+func (kC *KubeController) serviceEventParseAndSendData(obj interface{}, eventType string) {
+	objByte, err := json.Marshal(obj)
+	if err != nil {
+		klog.Errorf("[ERROR] Failed to Marshal original object: %v", err)
+	}
+	var objJson v1.Service
+	if err = json.Unmarshal(objByte, &objJson); err != nil {
+		klog.Errorf("[ERROR] Failed to unmarshal original object: %v", err)
+	}
+	if objJson.ObjectMeta.Namespace == "kube-system" {
+		return
+	}
+	message, err := json.MarshalIndent(objJson, "", "  ")
+	kC.parseAndSendData(string(message), objJson.ObjectMeta, objJson.TypeMeta, "Service", eventType)
+}
+
+func GenerateUUID() string {
+	uuid := uuid.New()
+	s := uuid.String()
+	return s
+}
+
+func (kC *KubeController) parseAndSendData(obj string, metaData metav1.ObjectMeta, metaHeader metav1.TypeMeta, kind string, objtype string) {
+	resp := make(map[string]string)
+	resp["app_event_id"] = GenerateUUID()
+	resp["resource_type"] = kind
+	resp["resource_name"] = metaData.Name
+	resp["resource_generations"] = string(metaData.Generation)
+	resp["resource_id"] = string(metaData.UID)
+	resp["app_environment_id"] = "joan-test"
+	resp["app_environment_type"] = "Kubernetes"
+	resp["type"] = objtype
+	resp["trig_time"] = ""
+	resp["server_group_id"] = metaData.Namespace
+	resp["resource_version"] = metaData.ResourceVersion
+	resp["message"] = obj
+	respJson, err := json.Marshal(resp)
+	if err != nil {
+		klog.Errorf("[ERROR] Failed to Marshal original object: %v", err)
+		fmt.Printf("[ERROR] Failed to Marshal original object: %v", err)
+	}
+	kC.sendData(bytes.NewBuffer(respJson))
+}
+
+func (kC *KubeController) sendData(data *bytes.Buffer) {
+	contr := *kC
+	//servers.mux.Lock()
+	fmt.Print("[INFO] Sending the data")
+	for _, v := range contr.ServerList {
+		tmp_data := *data
+		result, err := http.Post(v, "application/json", &tmp_data)
+		if err != nil {
+			fmt.Print("[INFO]", result, err)
+		}
+
+	}
+	//servers.mux.Unlock()
+}

--- a/pkg/kubeControls/kubeControls.go
+++ b/pkg/kubeControls/kubeControls.go
@@ -1,0 +1,66 @@
+/* kubeControls.go
+
+   This file contains kubernetes server details datastructure
+*/
+package kubeControls
+
+import (
+	"errors"
+	"k8s.io/api/core/v1"
+	"multicluster-ingress-controller/pkg/namespaces"
+	"multicluster-ingress-controller/pkg/swaggerInterface"
+	"strconv"
+)
+
+type KubeControl struct {
+	controlList []namespaces.Namespace
+}
+
+func New() *KubeControl {
+	return &KubeControl{}
+}
+
+func (kC *KubeControl) Namespaceslength() int {
+	return len(kC.controlList)
+}
+
+func (kC *KubeControl) GetNamespace(index int) (*namespaces.Namespace, error) {
+	length := len(kC.controlList)
+	if index >= length {
+		return nil, errors.New("KubeControl: Index out of bounds Index: " + strconv.Itoa(index) + " Length: " + strconv.Itoa(length))
+	}
+	return &kC.controlList[index], nil
+}
+
+func (kC *KubeControl) PopulateKubeControls(cS swaggerInterface.CreateClientServer) error {
+	err := kC.AddNamespaces(cS)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (kC *KubeControl) AddNamespaces(cS swaggerInterface.CreateClientServer) error {
+	var controlList []namespaces.Namespace
+	namespaceList := cS.Namespaces
+	if len(namespaceList) == 0 {
+		namespaceList = append(namespaceList, v1.NamespaceAll)
+	}
+	for _, v := range namespaceList {
+		nS := namespaces.New(v)
+		err := nS.AddEvents(cS)
+		if err != nil {
+			return err
+		}
+		controlList = append(controlList, *nS)
+	}
+	kC.controlList = controlList
+	return nil
+
+}
+func (kC *KubeControl) DeleteAll() {
+	for _, v := range kC.controlList {
+		v.DeleteAll()
+	}
+	kC.controlList = nil
+}

--- a/pkg/kubernetesAPIServer/kubernetesAPIServer.go
+++ b/pkg/kubernetesAPIServer/kubernetesAPIServer.go
@@ -1,0 +1,19 @@
+package kubernetesAPIServer
+
+import (
+	"k8s.io/client-go/kubernetes"
+)
+
+//This is interface for Kubernetes API Server
+type KubernetesAPIServer struct {
+	Suffix string
+	Client kubernetes.Interface
+}
+
+func New() *KubernetesAPIServer {
+	return &KubernetesAPIServer{}
+}
+
+func (kAS *KubernetesAPIServer) SetClient(client kubernetes.Interface) {
+	kAS.Client = client
+}

--- a/pkg/namespaces/namespaces.go
+++ b/pkg/namespaces/namespaces.go
@@ -1,0 +1,65 @@
+package namespaces
+
+import (
+	"errors"
+	"k8s.io/api/core/v1"
+	"multicluster-ingress-controller/pkg/events"
+	"multicluster-ingress-controller/pkg/swaggerInterface"
+	"strconv"
+)
+
+type Namespace struct {
+	namespaceName string
+	eventList     []events.Event
+}
+
+func New(namespaceName string) *Namespace {
+	return &Namespace{namespaceName: namespaceName}
+}
+
+func (nS *Namespace) AddEvents(cS swaggerInterface.CreateClientServer) error {
+	var evList []events.Event
+	for _, v := range cS.WatchEvents {
+		ev, err := events.New(v)
+		if err != nil {
+			return err
+		}
+		evList = append(evList, *ev)
+	}
+
+	nS.eventList = evList
+	return nil
+}
+
+func (nS *Namespace) DeleteAll() {
+	for _, e := range nS.eventList {
+		e.DeleteAll()
+	}
+	nS.eventList = nil
+}
+
+func (nS *Namespace) GetNamespaceName() string {
+	return nS.namespaceName
+}
+
+func (nS *Namespace) EventsLength() int {
+	return len(nS.eventList)
+}
+func (nS *Namespace) GetNamespaceString() string {
+	return GetNamespaceString(nS.namespaceName)
+}
+
+func GetNamespaceString(namespace string) string {
+	if namespace == v1.NamespaceAll {
+		return "allNamespace"
+	}
+	return namespace
+}
+
+func (nS *Namespace) GetEvent(index int) (*events.Event, error) {
+	length := len(nS.eventList)
+	if index > length {
+		return nil, errors.New("Namespaces: Out of bounds Index: " + strconv.Itoa(index) + "total length: " + strconv.Itoa(length))
+	}
+	return &nS.eventList[index], nil
+}

--- a/pkg/swaggerInterface/swaggerInterface.go
+++ b/pkg/swaggerInterface/swaggerInterface.go
@@ -1,0 +1,118 @@
+package swaggerInterface
+
+import (
+	"errors"
+	"fmt"
+	"k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog"
+	"multicluster-ingress-controller/pkg/kubernetesAPIServer"
+)
+
+type CreateClientServer struct {
+	ClusterName       string
+	ConfigFileName    string
+	KubeURL           string
+	KubeServAcctToken string
+	Namespaces        []string
+	ServerURL         []string
+	WatchEvents       []string
+}
+
+func New(configFile, kubeURL, kubeServAcctToken string) *CreateClientServer {
+	return &CreateClientServer{
+		ConfigFileName:    configFile,
+		KubeURL:           kubeURL,
+		KubeServAcctToken: kubeServAcctToken,
+	}
+}
+
+func (cS *CreateClientServer) ValidateKubeClusterFields() error {
+
+	configFile := cS.ConfigFileName
+	kubeURL := cS.KubeURL
+	kubeServAcctToken := cS.KubeServAcctToken
+
+	if configFile == "" && kubeURL == "" && kubeServAcctToken == "" {
+		fmt.Println("Service Account details are collected from POD")
+		return nil
+	}
+	if configFile == "" && kubeURL != "" && kubeServAcctToken != "" {
+		fmt.Println("Using kubeURL and kubeServAcctToken field for Kube Client configuration")
+		return nil
+	}
+	if configFile != "" {
+		fmt.Println("Using configFile for configuration")
+		return nil
+	}
+	if configFile == "" && kubeURL != "" && kubeServAcctToken == "" {
+		errString := "Kubernetes Cluster Service Account Token Not Present: Connection Parameters invalid"
+		fmt.Println(errString)
+		return errors.New(errString)
+	}
+	if configFile == "" && kubeURL == "" && kubeServAcctToken != "" {
+		errString := "Kubernetes Cluster URL Not Present: Connection Parameters invalid"
+		fmt.Println(errString)
+		return errors.New(errString)
+	}
+	return errors.New("Invalid Input Kubernetes connection Parameters")
+}
+
+/* This API creates Kubernetes client session. API requires config file or Kubernetes URL and Kubernetes Service Account Token.
+ * If file is not in default location, provide with path of the file.
+ */
+func (cS *CreateClientServer) CreateK8sApiserverClient() (*kubernetesAPIServer.KubernetesAPIServer, error) {
+	configFile := cS.ConfigFileName
+
+	klog.Info("[INFO] Creating API Client", configFile)
+	api := kubernetesAPIServer.New()
+	config, err := cS.getConfig()
+	if err != nil {
+		klog.Error("[ERROR] Failed to obtain Kubernetes Config")
+		return nil, err
+	}
+
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		klog.Error("[ERROR] Failed to establish connection")
+		klog.Fatal(err)
+	}
+	klog.Info("[INFO] Kubernetes Client is created")
+	api.SetClient(client)
+	return api, nil
+}
+
+// This function provides the kube client config file with the provided inputs
+func (cS *CreateClientServer) getConfig() (*restclient.Config, error) {
+	configFile := cS.ConfigFileName
+	kubeURL := cS.KubeURL
+	kubeServAcctToken := cS.KubeServAcctToken
+
+	if configFile != "" {
+		config, err := clientcmd.BuildConfigFromFlags("", configFile)
+		if err != nil {
+			klog.Error("[ERROR] Did not find valid kube config info")
+			return nil, err
+		}
+		return config, err
+	} else {
+		if configFile == "" && kubeURL == "" && kubeServAcctToken == "" {
+			config, err := clientcmd.BuildConfigFromFlags("", "")
+			if err != nil {
+				klog.Error("[WARNING] Citrix Node Controller Failed to create a Client")
+				return nil, err
+			}
+			return config, err
+		} else {
+			/* A valid KubeURL and Token scenario as the validation for the integrity
+			   of input Kube parameters are done at validateKubeClusterFields()
+			*/
+			return &restclient.Config{
+				Host:            kubeURL,
+				BearerToken:     kubeServAcctToken,
+				TLSClientConfig: restclient.TLSClientConfig{Insecure: true},
+			}, nil
+		}
+	}
+}

--- a/pkg/swaggerToKubeInterface/swaggerToKubeInterface.go
+++ b/pkg/swaggerToKubeInterface/swaggerToKubeInterface.go
@@ -1,0 +1,60 @@
+package swaggerToKubeInterface
+
+import (
+	"errors"
+	"fmt"
+	"multicluster-ingress-controller/pkg/kubeController"
+	"multicluster-ingress-controller/pkg/swaggerInterface"
+)
+
+type SwaggerToKubeInterface struct {
+	SwaggerClientServer *swaggerInterface.CreateClientServer
+	KController         *kubeController.KubeController
+}
+
+func (sTKI *SwaggerToKubeInterface) DeleteAll() {
+	sTKI.KController.DeleteAll()
+	sTKI.KController = nil
+	sTKI.SwaggerClientServer = nil
+}
+func (sTKI *SwaggerToKubeInterface) createLinkswgIntfToKubeController() error {
+
+	swgClientServer := *sTKI.SwaggerClientServer
+
+	err := swgClientServer.ValidateKubeClusterFields()
+	if err != nil {
+		return err
+	}
+
+	api, err := swgClientServer.CreateK8sApiserverClient()
+	if err != nil {
+		fmt.Println("Error while starting client API session")
+		return errors.New("Error while starting client API session: error: " + err.Error())
+	}
+
+	kC := kubeController.NewkubeController()
+	err = kC.PopulateKubeController(api, &swgClientServer)
+	if err != nil {
+		return errors.New("FAILURE: Kube Controller Add Fail: Error: " + err.Error())
+	}
+
+	(*sTKI).KController = kC
+	return nil
+
+}
+
+func (sTKI *SwaggerToKubeInterface) LinkAndStartWatchEvents() error {
+	err := sTKI.createLinkswgIntfToKubeController()
+
+	if err != nil {
+		return err
+	}
+	kubeController := *sTKI.KController
+	err = kubeController.RunWatchEvents()
+
+	if err != nil {
+		return errors.New("Invalid Controller Input: Error :" + err.Error())
+	}
+	return nil
+
+}


### PR DESCRIPTION
This diff does not have unit test changes

This diff  has the following changes

1) Events will be stopped when the server is deleted
2) Update a cluster resource is disabled. Can be taken up in the next bug
